### PR TITLE
fix: 🐛 pre-push のスクリプト動作が期待通りになるように修正した

### DIFF
--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -2,15 +2,16 @@
 set -euo pipefail
 
 PUSH_COMMAND_DETAIL=$(ps -ocommand= -p $PPID)
-PROHIBITED_COMMANDS='git push --force|git push -f'
+PROHIBITED_COMMANDS=("git push --force" "git push -f")
 ERROR_MESSAGE="ERROR: --force や -f オプションの使用は禁じられています。"
 
 echo "[LOG] git push コマンド (pre-push): $PUSH_COMMAND_DETAIL"
 
-if [[ $PUSH_COMMAND_DETAIL =~ $PROHIBITED_COMMANDS ]]; then
-  echo $ERROR_MESSAGE
-
-  exit 1
-fi
+for command in "${PROHIBITED_COMMANDS[@]}"; do
+  if [[ "$PUSH_COMMAND_DETAIL" == "$command" ]]; then
+    echo "$ERROR_MESSAGE"
+    exit 1
+  fi
+done
 
 exit 0


### PR DESCRIPTION
完全一致で判定しないと --force-with-lease --force-if-includes が実行できない
