### PR TITLE
feat: 🎸 Digdag のインストールスクリプトを追加した

### DIFF
--- a/initial_scripts_and_settings/scripts/install_digdag.sh
+++ b/initial_scripts_and_settings/scripts/install_digdag.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+cd "$(dirname "$0")"
+
+# NOTE: Java のバージョン依存が激しい…
+# https://docs.digdag.io/getting_started.html
+mkdir -p ~/.digdag
+curl -o ~/.digdag/digdag --create-dirs -L "https://dl.digdag.io/digdag-latest"
+chmod +x ~/.digdag/digdag
+
+echo 'シェルの設定ファイルに "export PATH=$HOME/.digdag:$PATH" を追加してください。'
+
+exit 0


### PR DESCRIPTION
けど、Java のバージョン依存が激しいので使わない可能性が高い

```bash
$ digdag --version
Unrecognized VM option 'AggressiveOpts'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```
