### PR TITLE
fix: 🐛 fvm のインストール場所の関係から sudo が必要なのでつけた

### DIFF
--- a/initial_scripts_and_settings/scripts/install_fvm.sh
+++ b/initial_scripts_and_settings/scripts/install_fvm.sh
@@ -2,9 +2,7 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-# macOS だと /usr/local/bin/fvm にシンボリックリンクを入れようとして sudo が必要になる
-# なので、面倒だから Homebrew で入れた方が良い（公式ドキュメント参照）
 # https://fvm.app/documentation/getting-started/installation
-curl -fsSL https://fvm.app/install.sh | bash
+curl -fsSL https://fvm.app/install.sh | sudo bash
 
 exit 0


### PR DESCRIPTION
- 公式ドキュメントにはついていないんだけどいいのかな
- OS は関係ない
    - Ubuntu でも macOS でも同じだった 

```bash
$ ./install_fvm.sh
Detected OS: linux
Detected Architecture: x64
Installing FVM version 3.2.1.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 3149k  100 3149k    0     0  4168k      0 --:--:-- --:--:-- --:--:-- 80.9M
ln: シンボリックリンク '/usr/local/bin/fvm' の作成に失敗しました: 許可がありません
error: Failed to create symlink.
```
