### PR TITLE
Revert "fix: 🐛 fvm のインストール場所の関係から sudo が必要なのでつけた (#380)"

### DIFF
--- a/initial_scripts_and_settings/scripts/install_fvm.sh
+++ b/initial_scripts_and_settings/scripts/install_fvm.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+# macOS だと /usr/local/bin/fvm にシンボリックリンクを入れようとして sudo が必要になる
+# なので、面倒だから Homebrew で入れた方が良い（公式ドキュメント参照）
 # https://fvm.app/documentation/getting-started/installation
-curl -fsSL https://fvm.app/install.sh | sudo bash
+curl -fsSL https://fvm.app/install.sh | bash
 
 exit 0


### PR DESCRIPTION
- This reverts commit 74e93210bb3d7546a5e594fddafa4acb3fa71ee8.
- 詳細は https://github.com/nikukyugamer/dotfiles/pull/380#issue-2957658228 の内容を参照のこと
    - 要は root ユーザのところに本体が入ってしまう 