### PR TITLE
feat: 🎸 uv tool のインストール先である ~/.local/bin を PATH に追加した

### DIFF
--- a/initial_scripts_and_settings/settings/.zshrc.userown.zshrc
+++ b/initial_scripts_and_settings/settings/.zshrc.userown.zshrc
@@ -17,8 +17,10 @@
 # https://qiita.com/homoluctus/items/ba1a6d03df85e65fc85a
 # alias sudo="sudo "
 
-# Rye
-# venv というエイリアスは衝突しそうで怖いので十分気をつけて意識しておく
+# uv tool
+# export PATH="$HOME/.local/bin:$PATH"
+
+# uv
 # alias venv=". .venv/bin/activate"
 
 # Lazygit


### PR DESCRIPTION
This pull request updates the `.zshrc.userown.zshrc` file to replace references to the `Rye` tool with the `uv` tool, including a commented-out `PATH` export for `uv`.

Shell configuration updates:

* Replaced the `Rye` tool references with `uv` tool references, including a commented-out `PATH` export line (`export PATH="$HOME/.local/bin:$PATH"`) and updated comments for clarity.