### PR TITLE
feat: 🎸 Rust (cargo) のインストールパッケージを追加した

### DIFF
--- a/initial_scripts_and_settings/scripts/install_packages_of_rust.sh
+++ b/initial_scripts_and_settings/scripts/install_packages_of_rust.sh
@@ -73,6 +73,8 @@ TARGET_PACKAGE_NAMES=(
   hyperfine
   kiro-editor
   macchina # https://github.com/Macchina-CLI/macchina
+  monolith # https://github.com/Y2Z/monolith
+  onefetch # https://github.com/o2sh/onefetch
   procs
   railwayapp
   ripgrep


### PR DESCRIPTION
This pull request updates the `initial_scripts_and_settings/scripts/install_packages_of_rust.sh` script by adding two new Rust-based tools to the list of target packages for installation.

Additions to target package list:

* Added `monolith`, a command-line tool for saving complete web pages as a single HTML file.
* Added `onefetch`, a command-line Git repository information tool that displays repository stats in a visually appealing format.monolith & onefetch
