### PR TITLE
Revert "feat: 🎸 gphotos-uploader-cli のインストールコードを追加した (#419)"

### DIFF
--- a/initial_scripts_and_settings/scripts/install_packages_of_golang.sh
+++ b/initial_scripts_and_settings/scripts/install_packages_of_golang.sh
@@ -19,7 +19,6 @@ go_install github.com/charmbracelet/vhs@latest
 go_install github.com/Clever/csvlint/cmd/csvlint@latest # https://github.com/Clever/csvlint
 go_install github.com/docker/hub-tool@latest            # GO111MODULE=on
 go_install github.com/go-delve/delve/cmd/dlv@latest     # for VSCode
-go_install github.com/gphotosuploader/gphotos-uploader-cli@latest
 go_install github.com/greymd/ojichat@latest
 go_install github.com/greymd/ojichatrix@latest
 go_install github.com/ipinfo/cli/ipinfo@latest   # IPinfo (https://ipinfo.io/)


### PR DESCRIPTION
- go install だと最新版が入らないのでやめた

This reverts commit cb292f67b4aaf717d76da1a90172338fa5aa3dd7.

This pull request makes a small update to the `install_packages_of_golang.sh` script by removing an unnecessary package installation.

* [`initial_scripts_and_settings/scripts/install_packages_of_golang.sh`](diffhunk://#diff-5e92f56b7d6bf62150d4651e6e277133ec13046fb84cae7e7184a59bb8d8ea6cL22): Removed the installation of `gphotos-uploader-cli` as it is no longer required.