### PR TITLE
feat: 🎸 Remove mise shell integrations

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -231,7 +231,7 @@ eval "$(direnv hook zsh)"
 # mise (https://mise.jdx.dev/)
 # cargo でインストールされる
 # バッティングするバージョン管理ツールがある場合は順番依存になるので注意すること
-eval "$(mise activate zsh)"
+# eval "$(mise activate zsh)"
 
 # --------------------------------------------------------------------------------
 # エイリアス


### PR DESCRIPTION
mise は Homebrew でインストールすることにしたので、シェル統合からは削除する。